### PR TITLE
Drop jenkins mocha

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
+
+[*.json]
+indent_size = 2

--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,4 @@ tests/
 docs/
 examples/
 Makefile
+.nyc_output

--- a/package.json
+++ b/package.json
@@ -3,9 +3,15 @@
   "version": "2.2.0",
   "description": "A module that produces hot badges without the need of Cairo",
   "main": "index.js",
+  "nyc": {
+    "reporter": [
+      "lcov",
+      "text"
+    ]
+  },
   "scripts": {
     "lint": "jshint *.js test/*.js",
-    "test": "jenkins-mocha"
+    "test": "nyc --report-dir ./artifacts/coverage mocha --color true"
   },
   "repository": {
     "type": "git",
@@ -30,8 +36,9 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "coveralls": "^3.0.11",
-    "jenkins-mocha": "^8.0.0",
     "jshint": "^2.11.0",
+    "mocha": "^7.1.1",
+    "nyc": "^15.0.0",
     "sinon": "^9.0.1"
   },
   "dependencies": {


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

As suggested in https://github.com/yahoo/badge-up/pull/12#issuecomment-602779538 , drops (now vulnerable) jenkins-mocha in favor of mocha + nyc.

Also:
- Avoids including coverage output in the npm package.
- Aligns `.editorconfig` per current JSON indenting standards
