### PR TITLE
feat: Update package.json for semantic release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badge-up",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "A module that produces hot badges without the need of Cairo",
   "main": "index.js",
   "nyc": {
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "lint": "jshint *.js test/*.js",
-    "test": "nyc --report-dir ./artifacts/coverage mocha --color true"
+    "test": "nyc --report-dir ./artifacts/coverage mocha --color true",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
     "type": "git",
@@ -30,6 +31,12 @@
     "Peter Peterson <petey@yahoo-inc.com>",
     "Robert Ames <rames@yahoo-inc.com>"
   ],
+  "release": {
+    "debug": false,
+    "verifyConditions": {
+      "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"
+    }
+  },
   "jshintConfig": {
     "node": true
   },


### PR DESCRIPTION
Still trying to get npm publish working with Screwdriver pipeline

Can see notifications-slack as an example: https://github.com/screwdriver-cd/notifications-slack/blob/master/package.json

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
