### PR TITLE
fix: update svgo to non-vulnerable version

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ Copyright (c) 2016, Yahoo Inc.
 Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
 */
 
-var fs = require('fs'),
+const fs = require('fs'),
     path = require('path'),
     {optimize} = require('svgo'),
     dot = require('dot'),
@@ -21,7 +21,7 @@ var fs = require('fs'),
  * @param  {Function} callback Function to call when done (error, SVG)
  */
 module.exports = async function badge (field1, field2, color, callback) {
-    var data = {
+    const data = {
             text: [
                 utils.escapeXml(field1),
                 utils.escapeXml(field2)

--- a/package.json
+++ b/package.json
@@ -43,16 +43,16 @@
     }
   },
   "devDependencies": {
-    "chai": "^4.2.0",
-    "coveralls": "^3.0.11",
-    "eslint": "^6.8.0",
-    "mocha": "^7.1.1",
-    "nyc": "^15.0.0",
-    "sinon": "^9.0.1"
+    "chai": "^4.3.4",
+    "coveralls": "^3.1.1",
+    "eslint": "^8.5.0",
+    "mocha": "^9.1.3",
+    "nyc": "^15.1.0",
+    "sinon": "^12.0.1"
   },
   "dependencies": {
     "css-color-names": "~1.0.1",
     "dot": "^1.1.3",
-    "svgo": "^1.3.2"
+    "svgo": "^2.8.0"
   }
 }

--- a/v2.js
+++ b/v2.js
@@ -3,7 +3,7 @@ Copyright (c) 2016, Yahoo Inc.
 Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
 */
 
-var colors = require('css-color-names'),
+const colors = require('css-color-names'),
     dot = require('dot'),
     fs = require('fs'),
     path = require('path'),
@@ -38,29 +38,26 @@ function getColorCode(input) {
 }
 
 function sectionsToData(sections) {
-    var badgeData = {
+    const badgeData = {
             width:      0,
             height:     0,
             sections:   [],
         };
     sections.forEach(function(section, s) {
-        var sectionData = {
-                x:      0,
-                width:  0,
-                lines:  [],
-            },
-            sectionHeight,
-            text,
-            lines;
+        const sectionData = {
+            x:      0,
+            width:  0,
+            lines:  [],
+        };
         if (! Array.isArray(section)) {
             section = [ section ];
         }
-        text = section.shift();
+        const text = section.shift();
         sectionData.x = badgeData.width;
         sectionData.color = (s === 0 ? DEFAULT_COLOR_FIRST : DEFAULT_COLOR_REST);
         section.forEach(function(attribute) {
             // stroke attribute `s{color}` as CSS color or color code in hex
-            var strokeAttribute = STROKE_REGEX.exec(attribute);
+            const strokeAttribute = STROKE_REGEX.exec(attribute);
             if (strokeAttribute) {
                 sectionData.stroke = getColorCode(strokeAttribute[1]) || null;
             }
@@ -72,22 +69,21 @@ function sectionsToData(sections) {
             // FUTURE -- text alignment `a{align}` lmr (only matters when multiline)
             // FUTURE -- font `f{font}` mainly for monospace (`fm`)
         });
-        lines = text.split('\n');
+        const lines = text.split('\n');
         lines.forEach(function(line, l) {
-            var lineData = {
-                    x:      0,
-                    y:      0,
-                    text:   line,
-                },
-                lineWidth;
-            lineWidth = (2 * PAD_X) + utils.textWidth(lineData.text, DEFAULT_LETTER_WIDTH);
+            const lineData = {
+                x:      0,
+                y:      0,
+                text:   line,
+            };
+            const lineWidth = (2 * PAD_X) + utils.textWidth(lineData.text, DEFAULT_LETTER_WIDTH);
             lineData.x = badgeData.width + PAD_X;
             lineData.y = (LINE_HEIGHT * l) + PAD_Y + LINE_HEIGHT - DECENDER_HEIGHT;
             sectionData.lines.push(lineData);
             sectionData.width = Math.max(sectionData.width, lineWidth);
         });
         badgeData.sections.push(sectionData);
-        sectionHeight = (2 * PAD_Y) + (lines.length * LINE_HEIGHT);
+        const sectionHeight = (2 * PAD_Y) + (lines.length * LINE_HEIGHT);
         badgeData.height = Math.max(badgeData.height, sectionHeight);
         badgeData.width += sectionData.width;
     });
@@ -96,7 +92,7 @@ function sectionsToData(sections) {
 
 
 module.exports = async function badge_v2(sections, callback) {
-    var raw = TEMPLATE(sectionsToData(sections))
+    const raw = TEMPLATE(sectionsToData(sections))
         // Due to https://github.com/svg/svgo/issues/1498
         .replace(/&#(x3c|60);/gi, '&lt;')
         .replace(/&#(x26|38);/gi, '&amp;');


### PR DESCRIPTION
- fix: update svgo to non-vulnerable version (older version relied on bad `css-select` -> `css-what`)

The vulnerability is described at https://snyk.io/vuln/SNYK-JS-CSSWHAT-1298035

Also:
1. updates devDeps.
2. fixes problem with numeric entities for `<` and `&` not being permissible when they should be (needed to keep a test passing as well as being a proper fix for [svgo #1498](https://github.com/svg/svgo/issues/1498))

Note that svgo changed their API from asynchronous to synchronous (see https://github.com/svg/svgo/releases/tag/v2.0.0 ). The reason I changed our functions to `async` (the syntax is ok because our `engines` range of Node 10+ as they were available [since Node 8](https://node.green/)) was to ensure they would continue returning a Promise, thus avoiding changing our own API. I think perhaps it is fine to continue having an async API since this is the kind of thing that could become async again, but it's not technically needed anymore.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
